### PR TITLE
Add full bestiary entries for Molten and Shade enemies

### DIFF
--- a/Bestiary & Reference/Monster Stat Blocks/Molten and Shade Enemies L2.md
+++ b/Bestiary & Reference/Monster Stat Blocks/Molten and Shade Enemies L2.md
@@ -1,0 +1,213 @@
+# Molten and Shade Enemies for Level 2 Parties
+
+These foes draw upon Ashqua's blazing corruption and Nerrath's chilling shadows. Each entry provides a complete stat block suitable for early-level adventurers.
+
+## Molten Creatures (Ashqua's Fire)
+
+### Molten Fireling (Minion)
+*Tiny elemental, unaligned*
+
+**Armor Class** 12
+**Hit Points** 5 (2d4)
+**Speed** 25 ft.
+
+|STR|DEX|CON|INT|WIS|CHA|
+|:--|:--|:--|:--|:--|:--|
+|8 (-1)|14 (+2)|10 (+0)|3 (-4)|10 (+0)|6 (-2)|
+
+**Damage Resistances** fire  
+**Damage Vulnerabilities** cold  
+**Senses** darkvision 30 ft., passive Perception 10  
+**Languages** understands Ignan but can't speak  
+**Challenge** 1/8 (25 XP)
+
+**Explosive Demise.** When the fireling dies, it bursts in flame. Each creature within 5 feet must succeed on a DC 10 Dexterity saving throw or take 2 (1d4) fire damage.
+
+#### Actions
+
+***Fiery Claws.*** *Melee Weapon Attack:* +4 to hit, reach 5 ft., one target. *Hit:* 3 (1d4 + 1) slashing damage plus 1 fire damage.
+
+Ashqua's tainted sparks swarm foes, ready to immolate themselves in fanatical devotion.
+
+### Charred Soldier (Elite)
+*Medium humanoid, chaotic evil*
+
+**Armor Class** 13 (scorched armor)
+**Hit Points** 18 (4d8)
+**Speed** 30 ft.
+
+|STR|DEX|CON|INT|WIS|CHA|
+|:--|:--|:--|:--|:--|:--|
+|13 (+1)|12 (+1)|12 (+1)|7 (-2)|10 (+0)|8 (-1)|
+
+**Damage Resistances** fire  
+**Senses** darkvision 60 ft., passive Perception 10  
+**Languages** Common, Ignan  
+**Challenge** 1/2 (100 XP)
+
+**Ashen Resilience.** Advantage on saving throws against being frightened or charmed.
+
+#### Actions
+
+***Burning Blade.*** *Melee Weapon Attack:* +3 to hit, reach 5 ft., one target. *Hit:* 5 (1d8 + 1) slashing damage plus 2 (1d4) fire damage.
+
+Former warriors twisted by Ashqua, their armor fused to charred flesh.
+
+### Ember Knight (Champion)
+*Medium humanoid, chaotic evil*
+
+**Armor Class** 15 (chain mail)
+**Hit Points** 27 (5d8 + 5)
+**Speed** 30 ft.
+
+|STR|DEX|CON|INT|WIS|CHA|
+|:--|:--|:--|:--|:--|:--|
+|14 (+2)|12 (+1)|13 (+1)|9 (-1)|11 (+0)|10 (+0)|
+
+**Damage Resistances** fire  
+**Senses** darkvision 60 ft., passive Perception 10  
+**Languages** Common, Ignan  
+**Challenge** 1 (200 XP)
+
+**Blazing Rush.** As a bonus action, the knight moves up to its speed without provoking opportunity attacks.
+
+**Fan the Flames (1/Day).** Allies within 10 feet gain a +1 bonus to attack rolls until the start of the knight's next turn.
+
+#### Actions
+
+***Heated Longsword.*** *Melee Weapon Attack:* +4 to hit, reach 5 ft., one target. *Hit:* 7 (1d8 + 2) slashing damage plus 2 (1d4) fire damage.
+
+Knights devoted to Ashqua brandish white-hot blades, spurring lesser Molten on.
+
+### Ashbound Herald (Boss)
+*Medium elemental, chaotic evil*
+
+**Armor Class** 14 (natural armor)
+**Hit Points** 45 (6d8 + 18)
+**Speed** 30 ft.
+
+|STR|DEX|CON|INT|WIS|CHA|
+|:--|:--|:--|:--|:--|:--|
+|16 (+3)|12 (+1)|16 (+3)|11 (+0)|12 (+1)|14 (+2)|
+
+**Damage Resistances** fire; **Damage Vulnerabilities** cold  
+**Senses** darkvision 60 ft., passive Perception 11  
+**Languages** Common, Ignan  
+**Challenge** 2 (450 XP)
+
+**Molten Command.** Molten allies within 30 feet can use their reactions to move up to 10 feet toward a target the herald chooses.
+
+#### Actions
+
+***Multiattack.*** The herald makes two Heated Spear attacks.
+
+***Heated Spear.*** *Melee or Ranged Weapon Attack:* +5 to hit, reach 5 ft. or range 20/60 ft., one target. *Hit:* 8 (1d6 + 3) piercing damage plus 3 (1d6) fire damage.
+
+***Searing Wave (Recharge 5–6).*** The herald releases a 15‑foot cone of flame. Each creature in that area must make a DC 12 Dexterity saving throw, taking 7 (2d6) fire damage on a failed save, or half as much on a successful one.
+
+Ashqua's chosen, these heralds stride through battle wreathed in flame.
+
+## Shade Creatures (Nerrath's Shadow)
+
+### Frostshade Wisp (Minion)
+*Tiny undead, neutral evil*
+
+**Armor Class** 13
+**Hit Points** 4 (1d4 + 2)
+**Speed** 0 ft., fly 30 ft. (hover)
+
+|STR|DEX|CON|INT|WIS|CHA|
+|:--|:--|:--|:--|:--|:--|
+|4 (-3)|15 (+2)|12 (+1)|3 (-4)|10 (+0)|6 (-2)|
+
+**Damage Resistances** cold; **Damage Vulnerabilities** fire  
+**Condition Immunities** prone  
+**Senses** darkvision 60 ft., passive Perception 10  
+**Languages** understands Common  
+**Challenge** 1/8 (25 XP)
+
+**Icy Fade.** Advantage on Dexterity (Stealth) checks in dim light or darkness.
+
+#### Actions
+
+***Chill Touch.*** *Melee Weapon Attack:* +4 to hit, reach 5 ft., one target. *Hit:* 3 (1d4 + 1) cold damage, and the target's speed is reduced by 5 feet until the start of the wisp's next turn.
+
+Fragments of frozen lunar spirits drift like shards of icy mist.
+
+### Mistblade (Elite)
+*Medium undead, neutral evil*
+
+**Armor Class** 14
+**Hit Points** 22 (5d8)
+**Speed** 30 ft.
+
+|STR|DEX|CON|INT|WIS|CHA|
+|:--|:--|:--|:--|:--|:--|
+|11 (+0)|16 (+3)|10 (+0)|8 (-1)|12 (+1)|9 (-1)|
+
+**Damage Resistances** cold  
+**Senses** darkvision 60 ft., passive Perception 11  
+**Languages** Common  
+**Challenge** 1/2 (100 XP)
+
+**Ethereal Step.** As a bonus action, the Mistblade can move through creatures and objects until the end of its turn.
+
+#### Actions
+
+***Frost Wound.*** *Melee Weapon Attack:* +5 to hit, reach 5 ft., one target. *Hit:* 6 (1d6 + 3) slashing damage plus 3 (1d6) cold damage.
+
+Shades loyal to Nerrath, they strike from swirling fog and vanish before retaliation.
+
+### Moon-Forged Knight (Champion)
+*Medium undead, lawful evil*
+
+**Armor Class** 16 (shield)
+**Hit Points** 30 (4d8 + 12)
+**Speed** 30 ft.
+
+|STR|DEX|CON|INT|WIS|CHA|
+|:--|:--|:--|:--|:--|:--|
+|15 (+2)|12 (+1)|16 (+3)|9 (-1)|12 (+1)|11 (+0)|
+
+**Damage Resistances** cold; **Damage Vulnerabilities** radiant  
+**Senses** darkvision 60 ft., passive Perception 11  
+**Languages** Common  
+**Challenge** 1 (200 XP)
+
+**Shield of Night.** When the knight takes damage, it grants an ally within 5 feet a +2 bonus to AC until the start of the knight's next turn.
+
+**Chilling Rebuke.** Once per round when hit by a melee attack, the knight deals 2 cold damage to the attacker.
+
+#### Actions
+
+***Longsword.*** *Melee Weapon Attack:* +4 to hit, reach 5 ft., one target. *Hit:* 7 (1d8 + 2) slashing damage plus 2 (1d4) cold damage.
+
+Clad in spectral moonlit armor, these warriors hold the line for Nerrath's forces.
+
+### Shroudcaller (Boss)
+*Medium undead, lawful evil*
+
+**Armor Class** 15 (natural armor)
+**Hit Points** 40 (6d8 + 12)
+**Speed** 30 ft., fly 30 ft. (hover)
+
+|STR|DEX|CON|INT|WIS|CHA|
+|:--|:--|:--|:--|:--|:--|
+|12 (+1)|14 (+2)|14 (+2)|13 (+1)|14 (+2)|15 (+2)|
+
+**Damage Resistances** cold, necrotic  
+**Damage Immunities** poison  
+**Condition Immunities** poisoned  
+**Senses** darkvision 60 ft., passive Perception 12  
+**Languages** Common  
+**Challenge** 2 (450 XP)
+
+**Haze of Despair (Recharge 5–6).** The Shroudcaller creates a 15‑foot‑radius cloud of cold shadows for 1 minute. Enemies entering or starting their turn in the cloud take 3 (1d6) cold damage, and the area is lightly obscured.
+
+**Raise Shade (1/Day).** The Shroudcaller animates a fallen humanoid within 30 feet as a Frostshade Wisp under its control.
+
+#### Actions
+
+***Spectral Scythe.*** *Melee Weapon Attack:* +4 to hit, reach 5 ft., one target. *Hit:* 8 (1d10 + 3) necrotic damage.
+
+Eerie commanders of Nerrath's remnants, Shroudcallers shroud battlefields in icy gloom and command the restless dead.


### PR DESCRIPTION
## Summary
- expand `Molten and Shade Enemies L2.md` with complete stat blocks for eight foes

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_685842096e148323b511f54195c165a5