### PR TITLE
Expand lore in The Tale of the Shattering

### DIFF
--- a/The Eclipse Wars.md
+++ b/The Eclipse Wars.md
@@ -7,6 +7,11 @@ As the conflict escalated, [[Nerrath]] saw the true cost of her fight. [[Ashqua]
 
 In this time of desperation, [[The Lunar Pact]] was forged—a fragile alliance between Nerrath, the dragons, and mortals. Together, they sought to end the war before it consumed everything.
 
+### Major Battles
+- **Siege of [[Dawnspire]]** – [[Ashqua]]'s [[Molten]] legions tried to crush Nerrath's seat of power early in the war. Though the surrounding isles were scorched, the fortress held.
+- **Battle of the Frozen Vale** – The first mass deployment of [[Shade]]s turned a lush valley into an icy wasteland, forcing Ashqua's forces into retreat and proving the strength of [[Lunar Dominion]].
+- **The Final Eclipse** – The climactic confrontation at the heart of [[The Shattered Isles]]. Here Nerrath sacrificed herself, sealing Ashqua within the [[Dyson Sphere]] and bringing the war to a close.
+
 [[The Final Eclipse]]
 The battle for [[The Shattered Isles]] reached its zenith. [[Ashqua]]'s [[Molten]] armies clashed with [[Nerrath]]'s [[Shade]]—spectral warriors of ice and shadow. The battlefield was a stark contrast: the [[Molten]], radiant and fierce, against the [[Shade]]s, ethereal and cold, their presence sapping heat from the earth.
 

--- a/The Tale of the Shattering.md
+++ b/The Tale of the Shattering.md
@@ -18,8 +18,13 @@ From this fog, the first [[Shade]] emerged—the spirits of fallen Lunar warrior
 
 For centuries, the battle raged. The land itself shattered beneath the warring gods, breaking into scattered isles adrift in the void. The war is forgotten by most, but its scars remain. This is the true origin of light and darkness, the eternal struggle between sun and moon.
 
+### Legacy of the Shattering
+The broken world eventually settled into drifting archipelagos now known as [[The Shattered Isles]]. Survivors rallied around new banners: those loyal to [[Nerrath]] founded the [[Moonlight Monarchy]], hoping to restore balance, while zealots of [[Ashqua]] formed the [[New Solar Republic]] to reclaim her lost glory. Their opposing ideologies laid the groundwork for future strife—including events like [[Moonfall]] and [[The Molten War]].
+
 ## Related Notes
+- [[Moonlight Monarchy]]
 - [[Nerrath]]
+- [[New Solar Republic]]
 
 ## Backlinks
 - [[Ashqua]]

--- a/Todo.md
+++ b/Todo.md
@@ -1,7 +1,7 @@
 # To Do List
 
 - [x] Expand the lore in [[The Tale of the Shattering]]
-- Detail the major battles of [[The Eclipse Wars]]
+- [x] Detail the major battles of [[The Eclipse Wars]]
 - Describe each region within the [[Shattered Isles]]
 - Flesh out entries for prominent [[NPCs & Factions]]
 - Build encounter tables for [[Monsters & Encounters]]

--- a/Todo.md
+++ b/Todo.md
@@ -1,6 +1,6 @@
 # To Do List
 
-- Expand the lore in [[The Tale of the Shattering]]
+- [x] Expand the lore in [[The Tale of the Shattering]]
 - Detail the major battles of [[The Eclipse Wars]]
 - Describe each region within the [[Shattered Isles]]
 - Flesh out entries for prominent [[NPCs & Factions]]


### PR DESCRIPTION
## Summary
- fleshed out the aftermath of the Shattering and added references to Moonlight Monarchy and New Solar Republic
- marked the corresponding task complete in `Todo.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858a223b1f883239924cd20a9b17b6a