### PR TITLE
Add Star-Sail Corsairs faction and crew notes

### DIFF
--- a/World Overview/Factions/Star-Sail Corsairs/Archaeologist Rowena 'Glyph-Shade'.md
+++ b/World Overview/Factions/Star-Sail Corsairs/Archaeologist Rowena 'Glyph-Shade'.md
@@ -1,0 +1,41 @@
+# Rowena "Glyph-Shade"
+
+Role: Archaeologist
+Race: Tiefling
+Pronouns: she/her
+Fighting Style: Rune-calling illusions
+Quirk: Slips into ancient tongues when excited
+Current Bounty: 11,000 gold
+
+Rowena's fascination with old civilizations led her to the Corsairs. She deciphers arcane ruins on the fly, weaving spectral constructs that confuse foes.
+
+### Rumors & Hooks
+- Pursued by a rival scholar claiming she stole an irreplaceable tablet.
+- Searching for pre-Shattering texts about a rumored sky-isle empire.
+- Might trade knowledge for access to restricted libraries.
+
+[[Star-Sail Corsairs]]
+
+### Expanded Details (Codex)
+**Statblock (D&D 5e)**
+*Medium humanoid (tiefling), neutral*
+
+**Armor Class** 13 (mage armor)
+**Hit Points** 58 (9d8 + 18)
+**Speed** 30 ft.
+
+|STR|DEX|CON|INT|WIS|CHA|
+|---|---|---|---|---|---|
+|9 (-1)|14 (+2)|14 (+2)|17 (+3)|13 (+1)|12 (+1)|
+
+**Saving Throws** Int +6, Wis +4
+**Skills** Arcana +6, History +6, Investigation +6
+**Senses** darkvision 60 ft., passive Perception 11
+**Languages** Common, Infernal, two ancient dialects
+**Challenge** 4 (1,100 XP)
+
+**Actions**
+- **Rune Bolt.** *Ranged Spell Attack:* +6 to hit, range 60 ft., one target. *Hit:* 9 (2d4 + 4) force damage.
+- **Illusory Double (Recharge 6).** Rowena creates a spectral duplicate within 30 ft. that distracts foes; creatures of her choice within 5 ft. of the duplicate have disadvantage on attack rolls until the start of her next turn.
+
+**Equipment** rune-etched focus, archaeologist’s tools, assorted scrolls

--- a/World Overview/Factions/Star-Sail Corsairs/Bard Bruk 'Soul-Chord'.md
+++ b/World Overview/Factions/Star-Sail Corsairs/Bard Bruk 'Soul-Chord'.md
@@ -1,0 +1,42 @@
+# Bruk "Soul-Chord"
+
+Role: Bard
+Race: Undead skeleton
+Pronouns: he/him
+Fighting Style: Soul-music illusions
+Quirk: Complains about lacking taste buds
+Current Bounty: 3,000 gold
+
+Bruk's enchanted violin draws echoes from the afterlife, weaving haunting melodies that unsettle foes. Despite his skeletal form, he's upbeat and fond of puns.
+
+### Rumors & Hooks
+- Searching for his original body, rumored to rest in a cursed mausoleum.
+- May know forgotten songs that unlock sealed tombs.
+- Collects stories of heroic deaths to add to his ballads.
+
+[[Star-Sail Corsairs]]
+
+### Expanded Details (Codex)
+**Statblock (D&D 5e)**
+*Medium undead, neutral*
+
+**Armor Class** 14 (mage armor)
+**Hit Points** 55 (10d8)
+**Speed** 30 ft.
+
+|STR|DEX|CON|INT|WIS|CHA|
+|---|---|---|---|---|---|
+|10 (+0)|16 (+3)|10 (+0)|14 (+2)|12 (+1)|18 (+4)|
+
+**Saving Throws** Dex +6, Cha +7
+**Skills** Performance +10, Deception +7, Insight +4
+**Damage Resistances** necrotic; bludgeoning, piercing, and slashing from nonmagical attacks
+**Senses** darkvision 60 ft., passive Perception 11
+**Languages** Common, one other
+**Challenge** 5 (1,800 XP)
+
+**Actions**
+- **Shortsword.** *Melee Weapon Attack:* +6 to hit, reach 5 ft., one target. *Hit:* 7 (1d6 + 3) piercing damage.
+- **Haunting Melody (Recharge 5–6).** Bruk plays a dissonant chord. Creatures of his choice within 20 ft. must succeed on a DC 15 Wisdom saving throw or become frightened until the end of their next turn.
+
+**Equipment** enchanted violin, shortsword, well-worn songbook

--- a/World Overview/Factions/Star-Sail Corsairs/Captain Lyffon 'Sky-Strider'.md
+++ b/World Overview/Factions/Star-Sail Corsairs/Captain Lyffon 'Sky-Strider'.md
@@ -1,0 +1,42 @@
+# Captain Lyffon "Sky-Strider"
+
+Role: Captain
+Race: Air genasi
+Pronouns: he/him
+Fighting Style: Cloud-grappling gauntlets
+Quirk: Laughs into the wind when leaping off ship rails
+Current Bounty: 15,000 gold
+
+Born amid the roaming isles, Lyffon assembled the Corsairs from misfits yearning for more than survival. His gauntlets let him fling himself between ships and clouds, turning risky boardings into his signature.
+
+### Rumors & Hooks
+- Seeks a legendary gauntlet upgrade buried within a drifting ruin.
+- Some say Lyffon once served the [[United Mortal Pact]] navy and stole their charts.
+- May trade secrets for maps of hidden [[Bad Lands]] passages.
+
+[[Star-Sail Corsairs]]
+
+### Expanded Details (Codex)
+**Statblock (D&D 5e)**
+*Medium humanoid (air genasi), chaotic good*
+
+**Armor Class** 15 (studded leather)
+**Hit Points** 85 (10d8 + 40)
+**Speed** 30 ft., fly 30 ft. (with gauntlets)
+
+|STR|DEX|CON|INT|WIS|CHA|
+|---|---|---|---|---|---|
+|14 (+2)|18 (+4)|18 (+4)|12 (+1)|11 (+0)|16 (+3)|
+
+**Saving Throws** Dex +8, Cha +7
+**Skills** Acrobatics +8, Athletics +6, Persuasion +7
+**Senses** passive Perception 10
+**Languages** Common, Auran
+**Challenge** 7 (2,900 XP)
+
+**Actions**
+- **Multiattack.** Lyffon makes two gauntlet strikes.
+- **Gauntlet Strike.** *Melee Weapon Attack:* +8 to hit, reach 5 ft., one target. *Hit:* 8 (1d8 + 4) bludgeoning damage. Lyffon may grapple the target and move up to 20 ft. without provoking opportunity attacks.
+- **Sky Leap (Recharge 5–6).** Lyffon leaps up to 60 ft. using his gauntlets, landing in an unoccupied space and making one gauntlet strike as part of the movement.
+
+**Equipment** studded leather armor, cloud-grappling gauntlets, navigator's charts

--- a/World Overview/Factions/Star-Sail Corsairs/Chef Sanqir 'Ember-Chef'.md
+++ b/World Overview/Factions/Star-Sail Corsairs/Chef Sanqir 'Ember-Chef'.md
@@ -1,0 +1,43 @@
+# Sanqir "Ember-Chef"
+
+Role: Chef
+Race: Fire genasi
+Pronouns: he/him
+Fighting Style: Flame-kicking martial arts
+Quirk: Seasons food mid-battle
+Current Bounty: 8,000 gold
+
+Sanqir treats every skirmish like a high-heat kitchen. He fuels his kicks with elemental fire while whipping up meals that keep morale high.
+
+### Rumors & Hooks
+- Hunting for spices said to grow only near erupting isles.
+- Wants to outperform renowned chefs of the [[Lunar Dominion]].
+- Rumored to have cooked for a dragon who still owes him a favor.
+
+[[Star-Sail Corsairs]]
+
+### Expanded Details (Codex)
+**Statblock (D&D 5e)**
+*Medium humanoid (fire genasi), chaotic good*
+
+**Armor Class** 15 (bracers of defense)
+**Hit Points** 70 (10d8 + 20)
+**Speed** 30 ft.
+
+|STR|DEX|CON|INT|WIS|CHA|
+|---|---|---|---|---|---|
+|13 (+1)|18 (+4)|14 (+2)|12 (+1)|10 (+0)|14 (+2)|
+
+**Saving Throws** Dex +7, Con +5
+**Skills** Acrobatics +7, Performance +5, Survival +3
+**Damage Resistances** fire
+**Senses** passive Perception 10
+**Languages** Common, Ignan
+**Challenge** 5 (1,800 XP)
+
+**Actions**
+- **Multiattack.** Sanqir makes two flaming kicks.
+- **Flaming Kick.** *Melee Weapon Attack:* +7 to hit, reach 5 ft., one target. *Hit:* 8 (1d8 + 4) bludgeoning damage plus 4 (1d8) fire damage.
+- **Spice Burst (Recharge 6).** Sanqir hurls a pouch of scorching spices at a point within 20 ft.; each creature in a 10-ft. radius must make a DC 15 Constitution save or be blinded until the end of its next turn.
+
+**Equipment** bracers of defense, cooking tools, spice pouches

--- a/World Overview/Factions/Star-Sail Corsairs/Healer Coppin 'Mend-Paw'.md
+++ b/World Overview/Factions/Star-Sail Corsairs/Healer Coppin 'Mend-Paw'.md
@@ -1,0 +1,42 @@
+# Coppin "Mend-Paw"
+
+Role: Healer
+Race: Ursine beastfolk
+Pronouns: she/her
+Fighting Style: Herbal remedies and sturdy claws
+Quirk: Keeps jars of honey-salve for every ailment
+Current Bounty: 2,000 gold
+
+Coppin once tended to wounded warriors in a forgotten hill clan. Her gentle demeanor belies a fearsome swipe when her friends are threatened.
+
+### Rumors & Hooks
+- Seeks rare herbs rumored to bloom only in moonlit ruins.
+- Some believe Coppin can commune with nature spirits of the Bad Lands.
+- Would pay handsomely for lost texts on druidic healing rituals.
+
+[[Star-Sail Corsairs]]
+
+### Expanded Details (Codex)
+**Statblock (D&D 5e)**
+*Medium humanoid (ursine beastfolk), neutral good*
+
+**Armor Class** 14 (natural armor)
+**Hit Points** 60 (8d8 + 24)
+**Speed** 30 ft.
+
+|STR|DEX|CON|INT|WIS|CHA|
+|---|---|---|---|---|---|
+|16 (+3)|12 (+1)|16 (+3)|11 (+0)|15 (+2)|13 (+1)|
+
+**Saving Throws** Wis +5, Con +6
+**Skills** Medicine +8, Nature +3, Animal Handling +5
+**Senses** passive Perception 12
+**Languages** Common, Sylvan
+**Challenge** 4 (1,100 XP)
+
+**Actions**
+- **Multiattack.** Coppin makes two claw attacks.
+- **Claw.** *Melee Weapon Attack:* +6 to hit, reach 5 ft., one target. *Hit:* 7 (1d6 + 3) slashing damage.
+- **Healing Salve (3/Day).** Coppin touches a creature to restore 10 (2d8 + 1) hit points and end one poison or disease affecting it.
+
+**Equipment** healer's kit, jars of honey-salve, sturdy travel clothes

--- a/World Overview/Factions/Star-Sail Corsairs/Helmsman Jinba 'Tide-Helm'.md
+++ b/World Overview/Factions/Star-Sail Corsairs/Helmsman Jinba 'Tide-Helm'.md
@@ -1,0 +1,41 @@
+# Jinba "Tide-Helm"
+
+Role: Helmsman
+Race: Leviathan-folk
+Pronouns: he/him
+Fighting Style: Water-bending maneuvers
+Quirk: Collects seashells for luck
+Current Bounty: 10,000 gold
+
+Jinba steers the Wandering Zephyr through the most treacherous currents with calm precision. His connection to the sea lets him sense shifts in the ether and weather alike.
+
+### Rumors & Hooks
+- Feuds with rival leviathan clans who claim he abandoned tradition.
+- Seeks a legendary compass said to guide any ship home.
+- Might aid those who respect ocean spirits and ancient tides.
+
+[[Star-Sail Corsairs]]
+
+### Expanded Details (Codex)
+**Statblock (D&D 5e)**
+*Medium humanoid (leviathan-folk), lawful neutral*
+
+**Armor Class** 16 (natural armor)
+**Hit Points** 88 (11d8 + 33)
+**Speed** 30 ft., swim 40 ft.
+
+|STR|DEX|CON|INT|WIS|CHA|
+|---|---|---|---|---|---|
+|18 (+4)|12 (+1)|17 (+3)|11 (+0)|14 (+2)|13 (+1)|
+
+**Saving Throws** Str +7, Wis +5
+**Skills** Vehicles (water) +8, Perception +5, Insight +5
+**Senses** darkvision 60 ft., passive Perception 15
+**Languages** Common, Aquan
+**Challenge** 6 (2,300 XP)
+
+**Actions**
+- **Trident.** *Melee Weapon Attack:* +7 to hit, reach 5 ft., one target. *Hit:* 9 (1d8 + 5) piercing damage.
+- **Water Jet (Recharge 5–6).** Jinba releases a 30-foot line of water that is 5 feet wide. Each creature in the line must succeed on a DC 15 Strength saving throw or be pushed 15 feet and knocked prone.
+
+**Equipment** trident, shell-adorned helm, navigational compass

--- a/World Overview/Factions/Star-Sail Corsairs/Navigator Nalara 'Storm-Chart'.md
+++ b/World Overview/Factions/Star-Sail Corsairs/Navigator Nalara 'Storm-Chart'.md
@@ -1,0 +1,41 @@
+# Nalara "Storm-Chart"
+
+Role: Navigator
+Race: Human
+Pronouns: she/her
+Fighting Style: Wind-scribing sigils
+Quirk: Draws maps on any spare surface
+Current Bounty: 9,000 gold
+
+Nalara was once an apprentice in the Moonlight Monarchy but chose freedom over rigid duty. Her wind-scribed charts allow the crew to ride volatile currents that other ships avoid.
+
+### Rumors & Hooks
+- Desperately seeks pieces of an ancient atlas rumored to predict isles' movements.
+- Has ties to the [[Moonlight Monarchy]] who want her talents back.
+- Offers guidance through [[Bad Lands]] storms for a share of discovered treasure.
+
+[[Star-Sail Corsairs]]
+
+### Expanded Details (Codex)
+**Statblock (D&D 5e)**
+*Medium humanoid (human), neutral*
+
+**Armor Class** 14 (leather armor)
+**Hit Points** 68 (8d8 + 32)
+**Speed** 30 ft.
+
+|STR|DEX|CON|INT|WIS|CHA|
+|---|---|---|---|---|---|
+|10 (+0)|14 (+2)|18 (+4)|16 (+3)|14 (+2)|12 (+1)|
+
+**Saving Throws** Int +6, Wis +5
+**Skills** Arcana +6, History +6, Nature +5, Perception +5
+**Senses** passive Perception 15
+**Languages** Common, Primordial
+**Challenge** 5 (1,800 XP)
+
+**Actions**
+- **Scribe Wind Sigil.** Nalara inscribes a floating rune within 30 ft. granting allies advantage on Dexterity saving throws until her next turn.
+- **Crossbow.** *Ranged Weapon Attack:* +5 to hit, range 80/320 ft., one target. *Hit:* 6 (1d8 + 2) piercing damage.
+
+**Equipment** leather armor, rune-etched crossbow, mapping tools

--- a/World Overview/Factions/Star-Sail Corsairs/Shipwright Frankeel 'Iron-Wake'.md
+++ b/World Overview/Factions/Star-Sail Corsairs/Shipwright Frankeel 'Iron-Wake'.md
@@ -1,0 +1,42 @@
+# Frankeel "Iron-Wake"
+
+Role: Shipwright
+Race: Dwarf
+Pronouns: he/him
+Fighting Style: Dracosteel enhancements and heavy wrench
+Quirk: Bursts into shanties while working
+Current Bounty: 6,000 gold
+
+Frankeel crafted the Corsairs' flagship from salvaged hulls and dracosteel plating. His inventions keep the ship skyworthy against all odds.
+
+### Rumors & Hooks
+- Seeking a legendary dracosteel forge lost among drifting wreckage.
+- Rivals in the [[Stonecarvers’ Guild]] want his schematics.
+- Will pay for rare parts from fallen skyships.
+
+[[Star-Sail Corsairs]]
+
+### Expanded Details (Codex)
+**Statblock (D&D 5e)**
+*Medium humanoid (dwarf), lawful good*
+
+**Armor Class** 17 (scale mail)
+**Hit Points** 80 (11d8 + 33)
+**Speed** 25 ft.
+
+|STR|DEX|CON|INT|WIS|CHA|
+|---|---|---|---|---|---|
+|18 (+4)|10 (+0)|16 (+3)|14 (+2)|12 (+1)|11 (+0)|
+
+**Saving Throws** Str +7, Con +6
+**Skills** Athletics +7, History +5, Smith’s Tools +8
+**Damage Resistances** poison
+**Senses** darkvision 60 ft., passive Perception 11
+**Languages** Common, Dwarvish
+**Challenge** 6 (2,300 XP)
+
+**Actions**
+- **Heavy Wrench.** *Melee Weapon Attack:* +7 to hit, reach 5 ft., one target. *Hit:* 10 (1d10 + 4) bludgeoning damage.
+- **Bolster Hull (Recharge 5–6).** Frankeel reinforces a vehicle or construct within 5 ft., granting it 15 temporary hit points for 1 hour.
+
+**Equipment** scale mail, heavy wrench, set of artisan’s tools, dracosteel scraps

--- a/World Overview/Factions/Star-Sail Corsairs/Star-Sail Corsairs.md
+++ b/World Overview/Factions/Star-Sail Corsairs/Star-Sail Corsairs.md
@@ -1,0 +1,36 @@
+# Star-Sail Corsairs
+
+Flagship: The Wandering Zephyr
+Captain: [[Captain Lyffon "Sky-Strider"]]
+Home-port: Roaming [[Bad Lands]] sky-isles
+Motive: Unearth ancient relics & lucrative bounties
+Known Bounties: Posted across the [[United Mortal Pact]] ports
+
+Formed by Captain Lyffon from wanderers and exiles, the Corsairs sweep across the Bad Lands in search of lost secrets and treasure. Their eclectic crew mirrors legendary pirate tropes while embracing the unique dangers of the Shattered Isles.
+
+**Crew Roster**
+- [[Captain Lyffon "Sky-Strider"]]
+- [[Swords-Ace "Sable Edge" Zorin]]
+- [[Navigator Nalara "Storm-Chart"]]
+- [[Trick-Shooter "Long-Eye" Ussik]]
+- [[Chef Sanqir "Ember-Chef"]]
+- [[Healer Coppin "Mend-Paw"]]
+- [[Archaeologist Rowena "Glyph-Shade"]]
+- [[Shipwright Frankeel "Iron-Wake"]]
+- [[Bard Bruk "Soul-Chord"]]
+- [[Helmsman Jinba "Tide-Helm"]]
+
+### Adventure Hooks
+- A map fragment hints at a storm-locked vault guarded by a rogue drake.
+- Rival factions hire Corsairs to retrieve a shattered relic said to command the winds.
+- Mysterious sky lights lure the crew toward an ancient arcane engine.
+
+#faction
+
+### Expanded Details (Codex)
+**Crew Statblock Highlights (D&D 5e)**
+The Star-Sail Corsairs travel aboard the *Wandering Zephyr*, a nimble airship with AC 15, 200 hit points, and a speed of 60 ft. (fly). When encountered together, the crew functions as a CR 9 encounter.
+
+- **Ballista Battery.** While all hands are on deck, the Corsairs can fire two ballistae (+6 to hit, 3d10 piercing damage). Loading a ballista requires one action from any crew member.
+- **Boarding Party.** On the first round of combat, Lyffon may launch up to four allies 60 ft. using his gauntlets, allowing them to board enemy vessels.
+- **Morale Surge.** When Bruk plays a rousing melody, each Corsair gains 5 temporary hit points at the start of combat.

--- a/World Overview/Factions/Star-Sail Corsairs/Swords-Ace 'Sable Edge' Zorin.md
+++ b/World Overview/Factions/Star-Sail Corsairs/Swords-Ace 'Sable Edge' Zorin.md
@@ -1,0 +1,42 @@
+# "Sable Edge" Zorin
+
+Role: Swords-ace
+Race: Half-elf
+Pronouns: he/him
+Fighting Style: Obsidian tri-blade mastery
+Quirk: Sleeps with blades within arm's reach
+Current Bounty: 12,000 gold
+
+Once a duelist renowned in sky-city arenas, Zorin fled after cutting down a corrupt patron. He now serves Lyffon with unwavering loyalty, carving a path through foes with his triple-bladed stance.
+
+### Rumors & Hooks
+- Hunted by former arena rivals seeking revenge.
+- Collects rare obsidian from shattered ruins to forge a final, perfect blade.
+- Might train those who prove themselves in honorable combat.
+
+[[Star-Sail Corsairs]]
+
+### Expanded Details (Codex)
+**Statblock (D&D 5e)**
+*Medium humanoid (half-elf), lawful neutral*
+
+**Armor Class** 16 (breastplate)
+**Hit Points** 75 (10d8 + 30)
+**Speed** 30 ft.
+
+|STR|DEX|CON|INT|WIS|CHA|
+|---|---|---|---|---|---|
+|17 (+3)|16 (+3)|16 (+3)|11 (+0)|12 (+1)|13 (+1)|
+
+**Saving Throws** Str +6, Dex +6
+**Skills** Athletics +6, Intimidation +4, Perception +4
+**Senses** passive Perception 14
+**Languages** Common, Elvish
+**Challenge** 6 (2,300 XP)
+
+**Actions**
+- **Multiattack.** Zorin makes three attacks with his tri-blades.
+- **Obsidian Slash.** *Melee Weapon Attack:* +6 to hit, reach 5 ft., one target. *Hit:* 9 (1d8 + 5) slashing damage.
+- **Whirlwind Parry.** Zorin adds +2 to his AC against one melee attack that would hit him.
+
+**Equipment** breastplate, three obsidian blades, sharpening kit

--- a/World Overview/Factions/Star-Sail Corsairs/Trick-Shooter 'Long-Eye' Ussik.md
+++ b/World Overview/Factions/Star-Sail Corsairs/Trick-Shooter 'Long-Eye' Ussik.md
@@ -1,0 +1,42 @@
+# "Long-Eye" Ussik
+
+Role: Trick-shooter
+Race: Goblin
+Pronouns: he/him
+Fighting Style: Alchemical trick shots
+Quirk: Tells outrageous tall tales
+Current Bounty: 5,000 gold
+
+Ussik crafts his own ammo—volatile concoctions that burst into smoke, fire, or sticky goo. His steady aim and constant boasting keep the crew entertained and enemies guessing.
+
+### Rumors & Hooks
+- Claims to know the location of a hidden goblin armory in the [[Bad Lands]].
+- Wants rare reagents from [[Galazeth]] to improve his formulas.
+- Rumored to exaggerate his feats; a rival may expose his lies.
+
+[[Star-Sail Corsairs]]
+
+### Expanded Details (Codex)
+**Statblock (D&D 5e)**
+*Small humanoid (goblin), chaotic neutral*
+
+**Armor Class** 15 (studded leather)
+**Hit Points** 52 (8d6 + 24)
+**Speed** 30 ft.
+
+|STR|DEX|CON|INT|WIS|CHA|
+|---|---|---|---|---|---|
+|8 (-1)|18 (+4)|16 (+3)|13 (+1)|12 (+1)|10 (+0)|
+
+**Saving Throws** Dex +7, Con +6
+**Skills** Sleight of Hand +7, Deception +3, Stealth +7
+**Senses** darkvision 60 ft., passive Perception 11
+**Languages** Common, Goblin
+**Challenge** 4 (1,100 XP)
+
+**Actions**
+- **Multiattack.** Ussik makes two alchemical pistol attacks.
+- **Alchemical Pistol.** *Ranged Weapon Attack:* +7 to hit, range 40/160 ft., one target. *Hit:* 8 (1d8 + 4) piercing damage plus 3 (1d6) elemental damage of Ussik's choice (fire, acid, or cold).
+- **Sticky Bomb (Recharge 5–6).** Ussik lobs a sticky concoction at a point he can see within 30 ft.; creatures in a 5-ft. radius must succeed on a DC 14 Dexterity saving throw or be restrained by goo (escape DC 14).
+
+**Equipment** studded leather armor, alchemical pistol, bandolier of trick shots


### PR DESCRIPTION
## Summary
- introduce Star-Sail Corsairs faction to World Overview
- add notes for the flagship crew members
- include D&D 5e statblocks for each Corsair and the crew as a whole

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686087bd4658832383b5ec4042d0bd76