### PR TITLE
Add background details for outlaw NPCs

### DIFF
--- a/NPCs & Factions/Minor NPCs/Brother Clastor.md
+++ b/NPCs & Factions/Minor NPCs/Brother Clastor.md
@@ -1,0 +1,28 @@
+# Brother Clastor
+
+Role: Molten cult preacher
+Race: Human\tPronouns: he/him
+Appearance: Charred robes cling to a frame that flickers with ember light.
+Signature Gear / Abilities:
+• Molten-laced flail preaching Ashqua's fury
+• Fiery sermons that sway desperate crowds
+Quirk: Whispers Ashqua's hymns even while sleeping.
+Infamy / Bounty: 5,000 gp.
+
+Nation – [[New Solar Republic]]
+Island – [[Dawnshard]]
+Town / City of Origin – [[Brimstone]], forge-town buried in ash.
+Likes – fervent converts, molten miracles.
+Dislikes – cold rain, mockery.
+Motivations –
+• Ignite devotion everywhere
+• Gather star shards for rites
+Goals –
+Short-term: establish a hidden shrine in [[Fort Ardenu]].
+Long-term: spark a second Molten crusade.
+
+Rumors & Adventure Hooks
+Hook #1 Recruiting lost sailors to recover fallen-star shards for a new altar.
+Hook #2 His visions hint at a dormant [[Lunar Dominion]] relic buried beneath [[Galazeth]].
+
+[[Molten]] #NPC #Pirate

--- a/NPCs & Factions/Minor NPCs/Captain Syrra Blackwake.md
+++ b/NPCs & Factions/Minor NPCs/Captain Syrra Blackwake.md
@@ -1,0 +1,28 @@
+# Captain Syrra "Blackwake"
+
+Role: Pirate captain  
+Race: Tiefling\tPronouns: she/her  
+Appearance: Charred horns crown her salt-bitten grin.
+Signature Gear / Abilities:  
+• Starshard cannon from wreck salvage
+• Shadow-step charm for quick boardings
+Quirk: Keeps a lantern glowing with faint lunar light.  
+Infamy / Bounty: 18,000 gp.
+
+Nation – [[Zonnewij Isels]]
+Island – [[Aschekilima]]
+Town / City of Origin – [[Zagenberg]], volcanic smuggler port.
+Likes – daring raids, polished starshard guns.
+Dislikes – Molten zealots, paperwork.
+Motivations –
+• Keep her crew feared everywhere
+• Hoard relics against Ashqua's flames
+Goals –
+Short-term: reclaim her map from [[Captain Lyffon "Sky-Strider"]].
+Long-term: found a floating port beyond all nations.
+
+Rumors & Adventure Hooks  
+Hook #1 Her crew scours New Solar Republic wrecks for a star shard said to ward off Molten flame.
+Hook #2 She hires cutthroats to steal back a prized map from [[Captain Lyffon "Sky-Strider"]].
+
+[[Bad Lands]] #NPC #Pirate

--- a/NPCs & Factions/Minor NPCs/Dorgo Greasestain.md
+++ b/NPCs & Factions/Minor NPCs/Dorgo Greasestain.md
@@ -1,0 +1,28 @@
+# Dorgo Greasestain
+
+Role: Smuggler
+Race: Goblin\tPronouns: he/him
+Appearance: Short and wiry, his patchwork coat perpetually stained with oil.
+Signature Gear / Abilities:
+• Clockwork glider for silent escapes
+• Hidden compartments sewn into every garment
+Quirk: Polishes his goggles whenever nervous.
+Infamy / Bounty: 2,000 gp.
+
+Nation – [[Gealaí Enclave]]
+Island – [[Críoch Skolvar]]
+Town / City of Origin – [[Galazeth]], smuggler port with dragon docks.
+Likes – clever contraptions, rare ciders.
+Dislikes – Molten inspections, long speeches.
+Motivations –
+• Stay ahead of customs
+• Pay off Corsair debts
+Goals –
+Short-term: slip Lunargold through [[Brigid]] unseen.
+Long-term: buy an airship and retire comfortably.
+
+Rumors & Adventure Hooks
+Hook #1 Smuggles [[Lunargold]] through [[Galazeth]], angering Molten cultists who want it for their rituals.
+Hook #2 Owes the [[Star-Sail Corsairs]] a favor and might barter stolen maps for protection.
+
+[[Galazeth]] #NPC #Pirate

--- a/NPCs & Factions/Minor NPCs/Grax Torch-Bane.md
+++ b/NPCs & Factions/Minor NPCs/Grax Torch-Bane.md
@@ -1,0 +1,28 @@
+# Grax "Torch-Bane"
+
+Role: Bounty hunter and former slaver
+Race: Hobgoblin\tPronouns: he/him
+Appearance: Patchwork armor etched with scorched runes and a sneer.
+Signature Gear / Abilities:
+• Molten-resistant chains for capturing prey
+• Heavy crossbow loaded with barbed bolts
+Quirk: Flips a coin to decide a captive's fate.
+Infamy / Bounty: 12,000 gp.
+
+Nation – [[United Mortal Pact]]
+Island – [[Mirrothal]]
+Town / City of Origin – [[Arrow Town]], famed for archery contests.
+Likes – bounties, oiled chains.
+Dislikes – sentimental marks, loose talk.
+Motivations –
+• Prove he's the most feared hunter
+• Fund his own fortress
+Goals –
+Short-term: catch a fugitive near [[Plasterhide]].
+Long-term: build a feared mercenary band.
+
+Rumors & Adventure Hooks
+Hook #1 Sells prisoners to hidden Ashqua zealots in the [[Bad Lands]].
+Hook #2 Hunts the same fallen-star map sought by [[Captain Syrra "Blackwake"]], willing to betray partners for it.
+
+[[Bad Lands]] #NPC #Pirate

--- a/NPCs & Factions/Minor NPCs/Kreeta Tide-Widow.md
+++ b/NPCs & Factions/Minor NPCs/Kreeta Tide-Widow.md
@@ -1,0 +1,28 @@
+# Kreeta "Tide-Widow"
+
+Role: Privateer
+Race: Orc\tPronouns: she/her
+Appearance: Weathered face etched with sea scars and a single gleaming tusk.
+Signature Gear / Abilities:
+• Harpoon-shotgun combo
+• Loyal drake "Brine" drags ships off course
+Quirk: Collects teeth from fallen foes.
+Infamy / Bounty: 14,000 gp.
+
+Nation – [[United Mortal Pact]]
+Island – [[Vermyrcove]]
+Town / City of Origin – [[Harpercourt]], wind-lashed cove where orcs train drakes.
+Likes – daring charges, bragging over drinks.
+Dislikes – cowardice, dock delays.
+Motivations –
+• Earn prize money for crew
+• Make her drake "Brine" feared
+Goals –
+Short-term: seize Lunargold from a wreck.
+Long-term: claim a noble title within the Pact.
+
+Rumors & Adventure Hooks
+Hook #1 Claims a drifting New Solar Republic wreck holds a trove of [[Lunargold]].
+Hook #2 Feuds with [[Captain Lyffon "Sky-Strider"]] over rights to a secret dock in the [[Bad Lands]].
+
+[[United Mortal Pact]] #NPC #Pirate

--- a/NPCs & Factions/Minor NPCs/Marnix the Whisper.md
+++ b/NPCs & Factions/Minor NPCs/Marnix the Whisper.md
@@ -1,0 +1,28 @@
+# Marnix the Whisper
+
+Role: Fence
+Race: Half-elf\tPronouns: they/them
+Appearance: Cloaked in muted colors, voice soft as wind in rigging.
+Signature Gear / Abilities:
+• Network of messenger birds carrying coded slips
+• Minor illusions to mask identity during deals
+Quirk: Speaks in rhymes when nervous.
+Infamy / Bounty: 8,000 gp.
+
+Nation – [[Gealaí Enclave]]
+Island – [[Críoch Skolvar]]
+Town / City of Origin – [[Brigid]], famed for healing springs.
+Likes – clever rhymes, quiet taverns.
+Dislikes – loud drunks, sunlight.
+Motivations –
+• Keep their info network humming
+• Stay neutral among crews
+Goals –
+Short-term: stash stolen map until heat fades.
+Long-term: open a secret market beyond wars.
+
+Rumors & Adventure Hooks
+Hook #1 Pressured by a Molten cult to find a star map stolen from [[New Solar Republic]] ruins.
+Hook #2 Seeks allies to steal a lunar relic from [[Star-Sail Corsairs]] before rivals do.
+
+[[Galazeth]] #NPC #Pirate

--- a/NPCs & Factions/Minor NPCs/Nimble Jak.md
+++ b/NPCs & Factions/Minor NPCs/Nimble Jak.md
@@ -1,0 +1,28 @@
+# Nimble Jak
+
+Role: Powder-monkey and pickpocket
+Race: Halfling\tPronouns: he/him
+Appearance: Tiny frame in an oversized jacket of pockets.
+Signature Gear / Abilities:
+• Quick hands adept at filching keys
+• Stash of smoke bombs for fast escapes
+Quirk: Constantly chewing spicy root.
+Infamy / Bounty: 500 gp.
+
+Nation – [[United Mortal Pact]]
+Island – [[Veltharion Reach]]
+Town / City of Origin – [[Last Hope]], windswept cliff outpost.
+Likes – spicy food, daring heists.
+Dislikes – heavy armor, long sermons.
+Motivations –
+• Prove he's more than hired help
+• Stay a step ahead of the law
+Goals –
+Short-term: sell the Molten ledger before the cult finds him.
+Long-term: captain his own swift skiff.
+
+Rumors & Adventure Hooks
+Hook #1 Overheard a vault route the [[Star-Sail Corsairs]] want; might sell it.
+Hook #2 Wants protection after stealing a Molten ledger implicating high-ranking pirates.
+
+[[Star-Sail Corsairs]] #NPC #Pirate

--- a/NPCs & Factions/Minor NPCs/Seraphine Moon-Bite.md
+++ b/NPCs & Factions/Minor NPCs/Seraphine Moon-Bite.md
@@ -1,0 +1,28 @@
+# Seraphine "Moon-Bite"
+
+Role: Slaver captain
+Race: Human\tPronouns: she/her
+Appearance: Silver hair braided with chains drapes over scarred shoulders.
+Signature Gear / Abilities:
+• Lunar-brand whip that leaves glowing marks
+• Shade-wisp familiar that scouts in darkness
+Quirk: Carves crescent notches into her belt after each capture.
+Infamy / Bounty: 25,000 gp.
+
+Nation – [[New Solar Republic]]
+Island – [[Dawnshard]]
+Town / City of Origin – [[Ayzat Heights]], spires choked by ash.
+Likes – obedient crews, moonlit raids.
+Dislikes – talk of redemption, meddling clerics.
+Motivations –
+• Keep control of her captives
+• Amass lunar relics for patrons
+Goals –
+Short-term: sell slaves to hidden cult.
+Long-term: gain influence in the [[Crescent Reavers]].
+
+Rumors & Adventure Hooks
+Hook #1 Traffics survivors from the [[New Solar Republic]] to a hidden Molten cult.
+Hook #2 Desperate to sell a stolen lunar relic before rivals realize its value.
+
+[[Crescent Reavers]] #NPC #Pirate


### PR DESCRIPTION
## Summary
- fleshed out pirate NPC notes with nation, island, and hometown info
- added likes, dislikes, motivations, and goals

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686093ac0c508323947d78528be34ec0