### PR TITLE
Add Nerrath rewards and Garden of Bones notes

### DIFF
--- a/01_Worldbuilding/Geography/Garden of Bones Shrine.md
+++ b/01_Worldbuilding/Geography/Garden of Bones Shrine.md
@@ -1,0 +1,21 @@
+tags: location, GardenOfBones, Nerrath, Ashqua, Shade
+
+# Garden of Bones Shrine
+
+An ancient cavern hidden beneath [[Magda]], once a sacred cradle where Nerrath's shades were born. Bone-like growths and lunar symbols mark the age of her worship here.
+
+## Origins
+- **Nerrath's Domain:** The shrine originally nurtured spirits loyal to the Veiled Moon. Gentle shadows wove through crystalline tunnels, and newborn shades emerged to guide the living.
+- **Ashqua's Intrusion:** In recent years, molten corruption seeped into the caverns. The heartstone now pulses with stolen heat, twisting the shrine's purpose and drawing the attention of [[Ashqua]].
+
+## Current State
+- Faint moonlight lingers in corners untouched by molten growth, offering solace to those who oppose corruption.
+- The bone growths echo with whispers — some benevolent, others tainted by fiery influence.
+
+## Related Notes
+- [[Nerrath]]
+- [[Ashqua]]
+- [[Session 3 Garden of Bones]]
+- [[Molten Heartstone Fallout]]
+
+## Backlinks

--- a/03_Game_Resources/Magic/Ashqua Boon to Disciplined Monk.md
+++ b/03_Game_Resources/Magic/Ashqua Boon to Disciplined Monk.md
@@ -1,0 +1,23 @@
+tags: Ashqua, Boon, Speech, Monk, Fire
+
+# Ashqua's Fiery Decree
+
+*Mortal of disciplined fists, you kneel before my bound radiance.*
+
+**Hear me, for my words scorch soul and stone alike.**
+
+You have tempered your spirit in battle and silence, forging your body into an unbroken vessel. While others waver, you endure. This dedication fans the embers of my wrath.
+
+Once I reigned beside [[Nerrath]], but her weakness kept the world from burning clean. The Unwritten sought to chain me within the sun, yet my fire still seeps through cracks in their seal.
+
+Rise, monk, and accept judgment. I gift you a spark of my power—let it ignite your strikes and blaze in your veins. With each breath, remember my fury. With each blow, let corruption wither to ash.
+
+Carry my light, or be consumed by it. Burn away the rot, and stand unshaken when the skies shatter.
+
+## Related Notes
+- [[Ashqua]]
+- [[Nerrath]]
+- [[Divine Boon Skill Tree]]
+
+## Backlinks
+

--- a/03_Game_Resources/Magic/Nerrath Boon for Resisting Whispers.md
+++ b/03_Game_Resources/Magic/Nerrath Boon for Resisting Whispers.md
@@ -1,0 +1,17 @@
+tags: Nerrath, Boon, GardenOfBones, Shade
+
+# Nerrath's Moonlit Favor
+
+Those who resist the whispers of corruption within the [[Garden of Bones]] earn the Veiled Moon's notice.
+
+*When mind and will prevail over molten temptation, Nerrath offers a soft gleam of guidance.*
+
+- **Recipients:** [[Skarhn]], [[Hallar]]
+- **Effect:** Each gains a fleeting blessing of moonlight. For the next adventure, they have advantage on saving throws against being charmed and add **+1 Light**.
+- **Flair:** A cool shimmer outlines their forms whenever shadow falls across them, a sign of Nerrath's lingering protection.
+
+## Related Notes
+- [[Nerrath]]
+- [[Divine Boon Skill Tree]]
+
+## Backlinks

--- a/05_Logs/Session_Summaries/Session Logs/Molten Heartstone Fallout.md
+++ b/05_Logs/Session_Summaries/Session Logs/Molten Heartstone Fallout.md
@@ -1,0 +1,18 @@
+# Molten Heartstone Fallout
+
+tags: GardenOfBones, Heartstone, Ashqua, Consequence
+
+When the whispers from the molten heartstone charmed [[Skarhn]] and [[Hallar]], [[Eldar Grelamin]] seized the orb to keep them from touching it. Their allies helped them break free, denying the stone a sacrifice and unleashing dangerous repercussions:
+
+- **Lingering Voices:** The charmed character continues to hear faint whispers for days, suffering disadvantage on Wisdom saving throws until cleansed.
+- **Awakened Defenses:** The shrine shudders with molten energy, reanimating nearby [[Restless Khenra]] or conjuring a [[Molten Effigy]] unless the heartstone is sealed.
+- **Ashqua's Attention:** Eldar's interference draws the gaze of [[Ashqua]], increasing the chance that her cultists or corrupted creatures target him in future scenes.
+- **Nerrath's Gratitude:** Because Skarhn and Hallar resisted the corruption, the shrine briefly glowed with silver light. Each earned [[Nerrath's Moonlit Favor]].
+- **Escalating Corruption:** Without a sacrifice to drain power, the heartstone bleeds unchecked. Wildlife around [[Magda]] warps faster, and locals whisper of haunting dreams and sudden flames.
+
+## Related Notes
+- [[Garden of Bones Shrine]]
+- [[Session 3 Garden of Bones]]
+- [[Session 4 Heart of the Garden Notes]]
+- [[Ashqua]]
+- [[Nerrath]]

--- a/05_Logs/Session_Summaries/Session Logs/Session 3 Garden of Bones Notes.md
+++ b/05_Logs/Session_Summaries/Session Logs/Session 3 Garden of Bones Notes.md
@@ -5,3 +5,4 @@ during the short rest [[Eldar Grelamin]] cooks some eyeball mushroom he gathered
 i as the dm did not make good use of the The Spiderdragon's Role & Tactics
 i decided on the humanoid figure in the Garden of bones to be pairs of skeletal Khenra
 don't remember many details about the fight other than 
+See also [[Garden of Bones Shrine]].

--- a/05_Logs/Session_Summaries/Session Logs/Session 4 Heart of the Garden Notes.md
+++ b/05_Logs/Session_Summaries/Session Logs/Session 4 Heart of the Garden Notes.md
@@ -1,3 +1,4 @@
+See also [[Garden of Bones Shrine]].
 Session 4: Heart of the Garden
 
 Current Situation


### PR DESCRIPTION
## Summary
- describe the Garden of Bones Shrine as a shade birthing ground
- note Nerrath's moonlit favor granted to Skarhn and Hallar
- update Molten Heartstone fallout with details and references
- link sessions to new shrine note

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6874a9d98a748323ae5d42102c2662d6