### PR TITLE
Add corrupted boar stat blocks

### DIFF
--- a/03_Game_Resources/Statblocks/Corrupted Boars of the Whispering Wilds.md
+++ b/03_Game_Resources/Statblocks/Corrupted Boars of the Whispering Wilds.md
@@ -1,0 +1,119 @@
+# Corrupted Boars of the [[Whispering Wilds]]
+Part of the [[Bestiary Index]]
+
+---
+
+### Rot-Bristled Boar  
+Tags: #creature #beast #corrupted #rot
+
+**Rot-Bristled Boar**  
+*Medium beast (corrupted), unaligned*  
+**Armor Class** 13 (scabbed hide)  
+**Hit Points** 26 (4d8 + 8)  
+**Speed** 40 ft.  
+
+|STR|DEX|CON|INT|WIS|CHA|
+|:--:|:--:|:--:|:--:|:--:|:--:|
+|15 (+2)|12 (+1)|15 (+2)|2 (−4)|9 (−1)|5 (−3)|
+
+**Skills** Perception +1  
+**Damage Resistances** necrotic  
+**Senses** passive Perception 11  
+**Languages** —  
+**Challenge** 1/2 (100 XP)
+
+***Rotting Bristles.*** A creature that hits the boar with a melee attack takes 3 (1d6) necrotic damage (DC 12 Con save halves).
+
+***Charge.*** If the boar moves at least 20 ft. straight toward a creature and then hits it with a tusk attack on the same turn, the target takes an extra 7 (2d6) piercing damage. If the target is a creature, it must succeed on a DC 12 Strength saving throw or be knocked prone.
+
+**Actions**  
+***Tusk.*** *Melee Weapon Attack:* +4 to hit, reach 5 ft., one target. *Hit:* 7 (1d8 + 2) piercing damage plus 3 (1d6) necrotic damage.
+
+**Mutational Lore.** Exposure to seepage from the [[Heartstone]] blackened the boar’s hide, the bristles fusing with necrotic growths that drip rot.
+
+**Encounter Notes.** Typically found rooting through carrion-strewn thickets; a pair will flank prey, snorting in a low, almost whispered cadence.
+
+**Environmental Impact.** Dead trees collapse under their trampling, the wood rotting in hours. Tracks: deep cloven prints with rivulets of black ichor.
+
+**Trophy Loot / Clues.** Brittle rot-bristles that still shed necrotic spores—useful as an alchemical reagent for decay-themed potions or as clues pointing toward the Heartstone’s corruption.
+
+---
+
+### Tuskgore Charger  
+Tags: #creature #beast #corrupted #charger
+
+**Tuskgore Charger**  
+*Medium beast (corrupted), unaligned*  
+**Armor Class** 14 (scarred hide)  
+**Hit Points** 52 (7d8 + 21)  
+**Speed** 40 ft.
+
+|STR|DEX|CON|INT|WIS|CHA|
+|:--:|:--:|:--:|:--:|:--:|:--:|
+|17 (+3)|12 (+1)|16 (+3)|2 (−4)|10 (+0)|6 (−2)|
+
+**Skills** Perception +2  
+**Damage Resistances** bludgeoning, piercing, and slashing from nonmagical attacks  
+**Senses** passive Perception 12  
+**Languages** —  
+**Challenge** 1 (200 XP)
+
+***Pack Tactics.*** The boar has advantage on an attack roll against a creature if at least one of the boar's allies is within 5 ft. of the creature and the ally isn't incapacitated.
+
+***Charging Fury.*** During the first round of combat, the boar has advantage on attack rolls against creatures it charges.
+
+**Actions**  
+***Tusk.*** *Melee Weapon Attack:* +5 to hit, reach 5 ft., one target. *Hit:* 11 (2d6 + 3) piercing damage. If the boar moved at least 20 ft. straight toward the target, it deals an extra 7 (2d6) piercing damage and the target must succeed on a DC 13 Strength saving throw or be knocked prone.
+
+**Mutational Lore.** The Shrine of Ayzat’s warped energies melted additional tusks from its jaw, granting a predatory hunger for coordinated ambushes.
+
+**Encounter Notes.** Travel in trios led by a dominant sow; they burst from underbrush or charge downhill slopes, striking like a living battering ram before allies follow.
+
+**Environmental Impact.** Scraped bark and toppled saplings mark their trails. The ground vibrates when a herd gathers momentum, hinting at distant trampling.
+
+**Trophy Loot / Clues.** Jagged tusks humming with faint crimson energy—can be fashioned into daggers that deal +1 damage against creatures affected by the Heartstone’s corruption.
+
+---
+
+### Fungal Matron  
+Tags: #creature #beast #corrupted #fungus
+
+**Fungal Matron**  
+*Large beast (corrupted), unaligned*  
+**Armor Class** 14 (fungal carapace)  
+**Hit Points** 95 (10d10 + 40)  
+**Speed** 40 ft.
+
+|STR|DEX|CON|INT|WIS|CHA|
+|:--:|:--:|:--:|:--:|:--:|:--:|
+|19 (+4)|8 (−1)|18 (+4)|3 (−4)|12 (+1)|6 (−2)|
+
+**Saving Throws** Con +7  
+**Skills** Perception +3  
+**Damage Resistances** poison; bludgeoning, piercing, and slashing from nonmagical attacks  
+**Condition Immunities** poisoned  
+**Senses** darkvision 60 ft., passive Perception 13  
+**Languages** —  
+**Challenge** 3 (700 XP)
+
+***Spore Sheath.*** Any creature that hits the matron with a melee attack takes 4 (1d8) poison damage and must succeed on a DC 14 Constitution saving throw or be poisoned until the end of its next turn.
+
+***Fungal Trail.*** Squares the matron moves through become lightly obscured and difficult terrain until the end of its next turn.
+
+**Actions**  
+***Multiattack.*** The matron makes two tusk attacks.  
+***Tusk.*** *Melee Weapon Attack:* +7 to hit, reach 5 ft., one target. *Hit:* 13 (2d8 + 4) piercing damage plus 4 (1d8) poison damage.  
+***Spore Burst (Recharge 5–6).*** The matron releases a cloud of spores in a 15‑ft. radius. Creatures in the area must make a DC 14 Constitution saving throw, taking 14 (4d6) poison damage on a failure or half on a success. A creature that fails is also blinded until the end of its next turn.
+
+**Mutational Lore.** Deep in the damp hollows near the [[Heartstone]], fungal colonies overgrew a sow, merging mind and mushroom into a brood leader.
+
+**Encounter Notes.** Commands lesser boars through guttural snorts; prefers marshy clearings or fungus-choked ravines where her spore cloud lingers.
+
+**Environmental Impact.** Surrounding flora is overtaken by pale molds; small animals flee the area or become spore-riddled husks. Tracking signs include hoofprints rimed with mycelium and a sour earthy scent.
+
+**Trophy Loot / Clues.** Hardened fungal plates (count as a shield granting advantage vs. poison); spores collected from her carcass can cure or cause diseases depending on preparation.
+
+---
+
+*Whispers of corrupted hoofbeats echo through the [[Whispering Wilds]], hinting that the Heartstone’s influence spreads farther each day.*
+


### PR DESCRIPTION
## Summary
- add Rot-Bristled Boar, Tuskgore Charger, and Fungal Matron stat blocks for the Whispering Wilds

## Testing
- no tests found

------
https://chatgpt.com/codex/tasks/task_e_688fba3e2b8c8323a515ad36f82c7eea